### PR TITLE
add synth.download info to fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ FROM ${BASE_REGISTRY}/ruby:${RUBY_VERSION}-slim-${DEBIAN_VERSION} AS ruby
 # Overwrite existence of 'alpha.X' in version.rb [--build-arg MASTODON_VERSION_PRERELEASE="nightly.2023.11.09"]
 ARG MASTODON_VERSION_PRERELEASE=""
 # Append build metadata or fork information to version.rb [--build-arg MASTODON_VERSION_METADATA="pr-123456"]
-ARG MASTODON_VERSION_METADATA=""
+ARG MASTODON_VERSION_METADATA="synthdownload"
 # Will be available as Mastodon::Version.source_commit
 ARG SOURCE_COMMIT=""
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# <img src="https://synth.download/assets/synth.download/synth.png" height="128"> Merpstodon
+
+A very light fork of [Chuckya](https://github.com/TheEssem/mastodon) with very minor changes that runs on [our Mastodon intsance](https://merping.synth.download).
+
+Changes currently including
+- Patches for PGroonga full text search support, over Elasticsearch
+- Custom Synth.download theme
+
+---
+
 # <img src="https://github.com/TheEssem/mastodon/raw/main/public/chuckya.svg" width="128"> Chuckya
 
 Chuckya is a close-to-upstream soft fork of Mastodon Glitch Edition (more commonly known as glitch-soc) that aims to introduce more experimental features/fixes with the goal of making the overall experience more enjoyable. Although it's mainly developed for and used on the [wetdry.world](https://wetdry.world) instance, it can be deployed by any server admin as a drop-in, backwards-compatible replacement for Mastodon.

--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -21,7 +21,7 @@ FROM ${BASE_REGISTRY}/node:${NODE_MAJOR_VERSION}-${DEBIAN_VERSION}-slim AS strea
 # Overwrite existence of 'alpha.X' in version.rb [--build-arg MASTODON_VERSION_PRERELEASE="nightly.2023.11.09"]
 ARG MASTODON_VERSION_PRERELEASE=""
 # Append build metadata or fork information to version.rb [--build-arg MASTODON_VERSION_METADATA="pr-123456"]
-ARG MASTODON_VERSION_METADATA=""
+ARG MASTODON_VERSION_METADATA="synthdownload"
 
 # Timezone used by the Docker container and runtime, change with [--build-arg TZ=Europe/Berlin]
 ARG TZ="Etc/UTC"


### PR DESCRIPTION
adds some synth.download changes

- *should* append `synth.download` to the version numbers in image builds
- readme update