### PR TITLE
properly change version to synth-soc

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,6 +1,9 @@
 name: Build nightly container image
 on:
   workflow_dispatch:
+  push:
+    paths-ignore: # don't rebuild if only documentation has changed
+      - "**.md"
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ FROM ${BASE_REGISTRY}/ruby:${RUBY_VERSION}-slim-${DEBIAN_VERSION} AS ruby
 # Overwrite existence of 'alpha.X' in version.rb [--build-arg MASTODON_VERSION_PRERELEASE="nightly.2023.11.09"]
 ARG MASTODON_VERSION_PRERELEASE=""
 # Append build metadata or fork information to version.rb [--build-arg MASTODON_VERSION_METADATA="pr-123456"]
-ARG MASTODON_VERSION_METADATA="synthdownload"
+ARG MASTODON_VERSION_METADATA=""
 # Will be available as Mastodon::Version.source_commit
 ARG SOURCE_COMMIT=""
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="https://synth.download/assets/synth.download/synth.png" height="128"> Merpstodon
 
-A very light fork of [Chuckya](https://github.com/TheEssem/mastodon) with very minor changes that runs on [our Mastodon intsance](https://merping.synth.download).
+A very light fork of [Chuckya](https://github.com/TheEssem/mastodon) with very minor changes that runs on [our Mastodon instance](https://merping.synth.download).
 
 Changes currently including
 - Patches for PGroonga full text search support, over Elasticsearch

--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -6,10 +6,10 @@ shared:
   software_update_url: <%= ENV.fetch('UPDATE_CHECK_URL', 'https://api.joinmastodon.org/update-check') %>
   source:
     base_url: <%= ENV.fetch('SOURCE_BASE_URL', nil) %>
-    repository: <%= ENV.fetch('GITHUB_REPOSITORY', 'TheEssem/mastodon') %>
+    repository: <%= ENV.fetch('GITHUB_REPOSITORY', 'melontini/mastodon') %>
     tag: <%= ENV.fetch('SOURCE_TAG', nil) %>
   version:
-    metadata: <%= ['chuckya', ENV.fetch('MASTODON_VERSION_METADATA', nil)].compact_blank.join('.') %>
+    metadata: <%= ['synth-soc', ENV.fetch('MASTODON_VERSION_METADATA', nil)].compact_blank.join('.') %>
     prerelease: <%= ENV.fetch('MASTODON_VERSION_PRERELEASE', nil) %>
 test:
   experimental_features: <%= [ENV.fetch('EXPERIMENTAL_FEATURES', nil), 'testing_only'].compact.join(',') %>

--- a/streaming/Dockerfile
+++ b/streaming/Dockerfile
@@ -21,7 +21,7 @@ FROM ${BASE_REGISTRY}/node:${NODE_MAJOR_VERSION}-${DEBIAN_VERSION}-slim AS strea
 # Overwrite existence of 'alpha.X' in version.rb [--build-arg MASTODON_VERSION_PRERELEASE="nightly.2023.11.09"]
 ARG MASTODON_VERSION_PRERELEASE=""
 # Append build metadata or fork information to version.rb [--build-arg MASTODON_VERSION_METADATA="pr-123456"]
-ARG MASTODON_VERSION_METADATA="synthdownload"
+ARG MASTODON_VERSION_METADATA=""
 
 # Timezone used by the Docker container and runtime, change with [--build-arg TZ=Europe/Berlin]
 ARG TZ="Etc/UTC"


### PR DESCRIPTION
changes a few things from #1:

- undo Dockerfile changes - the way the version is changed here *should* be the proper way to do it
- call it `synth-soc` instead
- also update `build-nightly.yml` to allow running whenever commits are pushed to the repo