### PR TITLE
update version to include "chuckya"

### DIFF
--- a/config/mastodon.yml
+++ b/config/mastodon.yml
@@ -12,7 +12,7 @@ shared:
     repository: <%= ENV.fetch('GITHUB_REPOSITORY', 'melontini/mastodon') %>
     tag: <%= ENV.fetch('SOURCE_TAG', nil) %>
   version:
-    metadata: <%= ['synth-soc', ENV.fetch('MASTODON_VERSION_METADATA', nil)].compact_blank.join('.').to_json %>
+    metadata: <%= ['chuckya+synth-soc', ENV.fetch('MASTODON_VERSION_METADATA', nil)].compact_blank.join('.').to_json %>
     prerelease: <%= ENV.fetch('MASTODON_VERSION_PRERELEASE', nil)&.to_json %>
 test:
   experimental_features: <%= [ENV.fetch('EXPERIMENTAL_FEATURES', nil), 'testing_only'].compact.join(',') %>


### PR DESCRIPTION
see https://github.com/ihateblueb/snowdrop/issues/73
basically it's just assumed to be normal mastodon bc of that